### PR TITLE
Add GenAI in Pharma workshop plan and tidy README

### DIFF
--- a/2026-06-16-GenAI-in-Pharma/plan.md
+++ b/2026-06-16-GenAI-in-Pharma/plan.md
@@ -36,4 +36,9 @@
 13. **Affordability of using AI**
     - Making things on the phone using Claude Code
 
-14. **People still hold the accountability**
+14. **Human oversight modes**
+    - Human-in-the-loop
+    - Human on the loop
+    - Human in command
+
+15. **People still hold the accountability**


### PR DESCRIPTION
## Summary

- Simplified README to a concise audience-facing index with PDF links
- Added `plan.md` inside `2026-06-16-GenAI-in-Pharma/` with the full workshop outline (15 topics)

https://claude.ai/code/session_016hHuqsUmTfCqTJZ8SkBeHy

---
_Generated by [Claude Code](https://claude.ai/code/session_016hHuqsUmTfCqTJZ8SkBeHy)_